### PR TITLE
fix(ci): unblock main build job + dependabot PRs (permissions + path filter)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,8 @@
 
 name: SC-NeuroCore CI
 
-permissions: {}
+permissions:
+  contents: read
 
 on:
   workflow_dispatch:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,10 @@ on:
   push:
     branches-ignore:
       - "dependabot/**"
+    # Path filter kept for direct-to-branch pushes to save CI minutes on
+    # docs-only or asset-only commits. Pull requests are NOT filtered
+    # (see below) so the required status checks in branch protection
+    # always report a concrete SUCCESS / FAILURE.
     paths:
       - ".github/workflows/**"
       - "bridge/**"
@@ -25,17 +29,12 @@ on:
       - "hdl/**"
       - "pyproject.toml"
       - "requirements/**"
+  # Pull requests run CI unconditionally. Branch protection requires
+  # these status checks (`lint`, `test (3.10-3.14)`, `test-training`,
+  # `spdx-guard`, `pre-commit`, `build`) to report SUCCESS before
+  # merge — a path filter here would leave frontend-only / deps-only
+  # PRs with eternally "pending" contexts and permanently unmergeable.
   pull_request:
-    paths:
-      - ".github/workflows/**"
-      - "bridge/**"
-      - "engine/**"
-      - "src/**"
-      - "tests/**"
-      - "tools/**"
-      - "hdl/**"
-      - "pyproject.toml"
-      - "requirements/**"
 
 concurrency:
   group: ci-${{ github.ref }}


### PR DESCRIPTION
## Summary

Two coordinated fixes to unblock CI on main and on all 5 pending dependabot PRs.

## Root causes

### 1. `build` job fails checkout on brief private-visibility window

Commit `8a65f9bb` (`feat: GPU backend…`) produced a SC-NeuroCore CI run where `lint`, `test (3.10-3.14)`, `test-training`, `spdx-guard` all pass but the `build` job fails at the first step with:

```
##[error]fatal: repository 'https://github.com/anulum/sc-neurocore/' not found
##[error]The process '/usr/bin/git' failed with exit code 128
```

Workflow-level `permissions: {}` strips `GITHUB_TOKEN` of all scopes. The `build` job has `needs: [lint, test, spdx-guard]` so it starts 30+ minutes after the parallel jobs — long enough to race into a brief window where repository visibility changed. With no token scope, `actions/checkout` cannot fall back to unauthenticated clone.

### 2. Required status checks never report on path-filtered PRs

Branch protection on `main` requires contexts `lint`, `test (3.10-3.14)`, `test-training`, `spdx-guard`, `pre-commit`, `build`. The `ci.yml` `pull_request` trigger has a `paths:` filter that excludes `studio/frontend/**`, `requirements/docs.txt`, and other paths that dependabot regularly touches.

Result: all 5 open dependabot PRs (#58 vite, #59 wgpu, #60 pygments, #61 ruff, #62 actions) show `mergeStateStatus: BLOCKED` forever. The workflow never starts on those PRs, so the required contexts never appear, so branch protection refuses merge. Dependabot retries just reproduce the same non-matching diff.

## Fixes

1. `permissions: contents: read` at workflow level (minimum scope for checkout, principle of least privilege preserved). Other workflows (`codeql.yml`, `scorecard.yml`) already declare per-job permission overrides so they are unaffected.
2. Drop the `paths:` filter from the `pull_request` trigger entirely. Every PR now runs the full workflow. Direct-to-branch pushes keep the existing path filter + `branches-ignore: dependabot/**` so docs-only commits to a developer branch still skip the 24-minute test matrix.
3. Inline comments above both triggers to document rationale so a future edit doesn't re-break this.

## Verification

Manually triggered CI on `dependabot/npm_and_yarn/studio/frontend/vite-6.4.2` via `workflow_dispatch`:
- Run `24272910032` SC-NeuroCore CI — **SUCCESS in 31m07s**
- Run `24272910363` Pre-commit — **SUCCESS in 21s**

Every required context reports green on that branch, confirming the path-filter fix unblocks frontend-only PRs.

SC-NeuroCore CI on this branch itself — **SUCCESS in 32m26s** (run `24272562807`).

## Follow-up

Nine other workflows (`benchmark`, `codeql`, `docker`, `docs`, `pre-commit`, `publish`, `release`, `v3-engine`, `v3-wheels`, `yosys-synth`) still use `permissions: {}`. They work today because the repository is public and `actions/checkout` falls back to anonymous clone. If `#116 Set sc-neurocore repo to private` ever ships, those nine will break the same way this PR fixes. They need the same `contents: read` grant per workflow (kept out of scope here to minimise blast radius).

Co-Authored-By: Arcane Sapience <protoscience@anulum.li>