### PR TITLE
fix(hygiene): neutralise local chat provider naming

### DIFF
--- a/docs/api/bridges/local_llm.md
+++ b/docs/api/bridges/local_llm.md
@@ -17,6 +17,6 @@ This bridge turns spike-derived summaries into prompts for a local model
 running behind either:
 
 - an Ollama chat endpoint
-- an OpenAI-compatible local server
+- a generic chat-completions local server
 
 It is explicitly local and opt-in.

--- a/docs/guides/local_llm_bridge.md
+++ b/docs/guides/local_llm_bridge.md
@@ -28,7 +28,7 @@ It does **not** alter any existing simulation path.
 It provides a local client around two endpoint styles:
 
 - Ollama chat API
-- OpenAI-compatible chat-completions API hosted locally
+- generic chat-completions API hosted locally
 
 ## Module
 
@@ -79,7 +79,7 @@ response = bridge.analyse_spike_raster(
 print(response.text)
 ```
 
-## Example: OpenAI-compatible local server
+## Example: Chat-Completions Local Server
 
 ```python
 from sc_neurocore.bridges.local_llm import (
@@ -91,7 +91,7 @@ from sc_neurocore.bridges.local_llm import (
 bridge = LocalLLMBridge(
     LocalLLMConfig(
         base_url="http://127.0.0.1:8000",
-        provider=LocalLLMProvider.OPENAI_COMPAT,
+        provider=LocalLLMProvider.CHAT_COMPLETIONS,
         model="local-model",
     )
 )

--- a/src/sc_neurocore/bridges/local_llm.py
+++ b/src/sc_neurocore/bridges/local_llm.py
@@ -12,7 +12,7 @@ This module is intentionally local-only and opt-in. It does not talk to any
 hosted service. Supported endpoint styles:
 
 - Ollama-style chat API at ``/api/chat``
-- OpenAI-compatible chat-completions API at ``/v1/chat/completions``
+- generic chat-completions API at ``/v1/chat/completions``
 
 The bridge is useful when SC-NeuroCore data should be explained or summarised
 through a locally hosted language model without introducing a cloud dependency.
@@ -40,7 +40,7 @@ class LocalLLMProvider(Enum):
 
     AUTO = "auto"
     OLLAMA = "ollama"
-    OPENAI_COMPAT = "openai_compat"
+    CHAT_COMPLETIONS = "chat_completions"
 
 
 @dataclass(frozen=True)
@@ -65,7 +65,7 @@ class LocalLLMConfig:
             return self.provider
         if ":11434" in self.base_url or self.base_url.rstrip("/").endswith("/api"):
             return LocalLLMProvider.OLLAMA
-        return LocalLLMProvider.OPENAI_COMPAT
+        return LocalLLMProvider.CHAT_COMPLETIONS
 
 
 @dataclass(frozen=True)
@@ -149,7 +149,7 @@ class LocalLLMBridge:
         provider = self.config.resolved_provider()
         if provider is LocalLLMProvider.OLLAMA:
             return f"{base}/api/chat"
-        if provider is LocalLLMProvider.OPENAI_COMPAT:
+        if provider is LocalLLMProvider.CHAT_COMPLETIONS:
             return f"{base}/v1/chat/completions"
         raise LocalLLMError(f"Unsupported provider: {provider.value}")
 
@@ -252,13 +252,13 @@ class LocalLLMBridge:
         raw = self._post_json(payload)
         choices = raw.get("choices")
         if not isinstance(choices, list) or not choices:
-            raise LocalLLMError("OpenAI-compatible response missing choices")
+            raise LocalLLMError("chat-completions response missing choices")
         first = choices[0]
         if not isinstance(first, dict):
-            raise LocalLLMError("OpenAI-compatible choice is malformed")
+            raise LocalLLMError("chat-completions choice is malformed")
         message = first.get("message")
         if not isinstance(message, dict) or not isinstance(message.get("content"), str):
-            raise LocalLLMError("OpenAI-compatible response missing choices[0].message.content")
+            raise LocalLLMError("chat-completions response missing choices[0].message.content")
         usage_obj = raw.get("usage")
         usage: dict[str, Any] = usage_obj if isinstance(usage_obj, dict) else {}
         prompt_tokens = usage.get("prompt_tokens")

--- a/tests/test_bridges/test_local_llm.py
+++ b/tests/test_bridges/test_local_llm.py
@@ -69,19 +69,19 @@ def test_chat_ollama_parses_response(monkeypatch: pytest.MonkeyPatch) -> None:
     assert result.completion_tokens == 9
 
 
-def test_chat_openai_compat_parses_response(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_chat_completions_parses_response(monkeypatch: pytest.MonkeyPatch) -> None:
     bridge = LocalLLMBridge(
         LocalLLMConfig(
             base_url="http://127.0.0.1:8000",
-            provider=LocalLLMProvider.OPENAI_COMPAT,
-            model="local-openai",
+            provider=LocalLLMProvider.CHAT_COMPLETIONS,
+            model="local-chat",
         )
     )
 
     def fake_post(payload: dict[str, object]) -> dict[str, object]:
-        assert payload["model"] == "local-openai"
+        assert payload["model"] == "local-chat"
         return {
-            "model": "local-openai",
+            "model": "local-chat",
             "choices": [
                 {
                     "message": {"role": "assistant", "content": "compat answer"},
@@ -94,7 +94,7 @@ def test_chat_openai_compat_parses_response(monkeypatch: pytest.MonkeyPatch) -> 
     monkeypatch.setattr(bridge, "_post_json", fake_post)
     result = bridge.chat("hello")
     assert result.text == "compat answer"
-    assert result.model == "local-openai"
+    assert result.model == "local-chat"
     assert result.prompt_tokens == 21
     assert result.completion_tokens == 11
 
@@ -124,11 +124,11 @@ def test_post_json_timeout_raises_local_error(monkeypatch: pytest.MonkeyPatch) -
 def test_post_json_rejects_non_http_scheme() -> None:
     bridge = LocalLLMBridge(
         LocalLLMConfig(
-            base_url="file:///tmp/local-model.sock", provider=LocalLLMProvider.OPENAI_COMPAT
+            base_url="file:///tmp/local-model.sock", provider=LocalLLMProvider.CHAT_COMPLETIONS
         )
     )
     with pytest.raises(LocalLLMError, match="http or https"):
-        bridge._post_json({"model": "local-openai", "messages": []})
+        bridge._post_json({"model": "local-chat", "messages": []})
 
 
 def test_post_json_rejects_non_loopback_host() -> None:
@@ -140,7 +140,7 @@ def test_post_json_rejects_non_loopback_host() -> None:
 
 
 def test_analyse_spike_raster_forwards_summary(monkeypatch: pytest.MonkeyPatch) -> None:
-    bridge = LocalLLMBridge(LocalLLMConfig(provider=LocalLLMProvider.OPENAI_COMPAT))
+    bridge = LocalLLMBridge(LocalLLMConfig(provider=LocalLLMProvider.CHAT_COMPLETIONS))
     captured_prompt: dict[str, str] = {}
     original_chat = bridge.chat
 
@@ -158,7 +158,7 @@ def test_analyse_spike_raster_forwards_summary(monkeypatch: pytest.MonkeyPatch) 
 
     def fake_post(_payload: dict[str, object]) -> dict[str, object]:
         return {
-            "model": "local-openai",
+            "model": "local-chat",
             "choices": [
                 {"message": {"role": "assistant", "content": "analysis"}, "finish_reason": "stop"}
             ],

--- a/tests/test_explainability/test_explainability.py
+++ b/tests/test_explainability/test_explainability.py
@@ -564,7 +564,7 @@ class TestNaturalLanguageExplainer:
         tree = SpikeDecisionTree()
         bs = np.ones(100, dtype=np.uint8)
         node = tree.add_decision("n0", bs, threshold=50)
-        bridge = LocalLLMBridge(LocalLLMConfig(provider=LocalLLMProvider.OPENAI_COMPAT))
+        bridge = LocalLLMBridge(LocalLLMConfig(provider=LocalLLMProvider.CHAT_COMPLETIONS))
 
         def fake_chat(user_prompt: str, **_kwargs):
             assert "Base explanation:" in user_prompt
@@ -682,7 +682,7 @@ class TestEngineIntegration:
 
     def test_explain_spike_with_local_llm(self, monkeypatch):
         engine = ExplainabilityEngine(seed=0xACE1)
-        bridge = LocalLLMBridge(LocalLLMConfig(provider=LocalLLMProvider.OPENAI_COMPAT))
+        bridge = LocalLLMBridge(LocalLLMConfig(provider=LocalLLMProvider.CHAT_COMPLETIONS))
 
         def fake_chat(user_prompt: str, **_kwargs):
             assert "Base explanation:" in user_prompt


### PR DESCRIPTION
## Summary\n- replace vendor-specific local chat provider naming with generic chat-completions naming\n- update local LLM bridge docs, enum, errors, and tests\n- keep loopback-only /v1/chat/completions behaviour intact\n\n## Verification\n- git diff --cached --check\n- added-line public agent-name scan\n- ruff check src/sc_neurocore/bridges/local_llm.py tests/test_bridges/test_local_llm.py tests/test_explainability/test_explainability.py\n- ruff format --check same files\n\n## Note\n- Targeted pytest collection in the temporary worktree is blocked by the missing native engine build in that worktree; hosted CI should run the repository build path.